### PR TITLE
feat(build): electron-builder ad-hoc code signing for macOS (#36)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -23,6 +23,10 @@ win:
         - "x64"
 mac:
   category: "public.app-category.education"
+  # ad-hoc code signing removes Gatekeeper warnings on macOS (free, no Apple Developer ID required)
+  codesignIdentity: "-"
+  entitlements: "resources/entitlements.plist"
+  entitlementsInherit: "resources/entitlements.plist"
   target:
     - target: "dmg"
       arch:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src/**/*.{ts,vue} --quiet",
     "lint:fix": "eslint src/**/*.{ts,vue} --fix",
     "format": "prettier --check src/**/*.{ts,vue,css,json}",
-    "format:fix": "prettier --write src/**/*.{ts,vue,css,json}"
+    "format:fix": "prettier --write src/**/*.{ts,vue,css,json}",
+    "build:mac": "cd .. && npx electron-builder --mac"
   },
   "dependencies": {
     "vue": "3.4.21",

--- a/resources/entitlements.plist
+++ b/resources/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
## Summary
Configures ad-hoc code signing for macOS builds so the Electron app opens without Gatekeeper warnings.

## Changes
- `electron-builder.yml`: added `mac.codesignIdentity: "-"` and pointed `mac.entitlements` + `mac.entitlementsInherit` to `resources/entitlements.plist`
- Created `resources/entitlements.plist` with `com.apple.security.cs.allow-jit`, `allow-unsigned-executable-memory`, and `allow-dyld-environment-variables`
- Added `build:mac` script to `frontend/package.json`

## Test Plan
- Build on macOS with `cd frontend && npm run build:mac`

Closes #36
