### PR TITLE
feat: real-time pipeline progress reporting (#44)

### DIFF
--- a/backend/app/database/migrations/versions/002_add_jobs_table.py
+++ b/backend/app/database/migrations/versions/002_add_jobs_table.py
@@ -1,0 +1,44 @@
+"""Add jobs table for pipeline progress tracking.
+
+Revision ID: 002_add_jobs_table
+Revises: 001_init
+Create Date: 2026-04-27
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002_add_jobs_table"
+down_revision: Union[str, None] = "001_init"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Integer(), primary_key=True, index=True),
+        sa.Column(
+            "doc_id", sa.Integer(), sa.ForeignKey("documents.id"), nullable=False, index=True
+        ),
+        sa.Column("stage", sa.String(), nullable=False, default="uploaded"),
+        sa.Column("progress", sa.Float(), nullable=False, default=0.0),
+        sa.Column("error_msg", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("jobs")

--- a/backend/app/database/migrations/versions/002_add_jobs_table.py
+++ b/backend/app/database/migrations/versions/002_add_jobs_table.py
@@ -23,7 +23,11 @@ def upgrade() -> None:
         "jobs",
         sa.Column("id", sa.Integer(), primary_key=True, index=True),
         sa.Column(
-            "doc_id", sa.Integer(), sa.ForeignKey("documents.id"), nullable=False, index=True
+            "doc_id",
+            sa.Integer(),
+            sa.ForeignKey("documents.id"),
+            nullable=False,
+            index=True,
         ),
         sa.Column("stage", sa.String(), nullable=False, default="uploaded"),
         sa.Column("progress", sa.Float(), nullable=False, default=0.0),

--- a/backend/app/database/models.py
+++ b/backend/app/database/models.py
@@ -4,12 +4,38 @@ from typing import Any, List, Optional
 
 from app.entities.document import Document
 from app.entities.edge import Edge
+from app.entities.job import Job
 from app.entities.node import Node
 from app.entities.quiz import Question, Quiz
 from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
+
+
+class JobModel(Base):
+    __tablename__ = "jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    doc_id = Column(Integer, ForeignKey("documents.id"), nullable=False, index=True)
+    stage = Column(String, nullable=False, default="uploaded")
+    progress = Column(Float, nullable=False, default=0.0)
+    error_msg = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    def to_domain(self) -> Job:
+        return Job(
+            id=self.id,
+            doc_id=self.doc_id,
+            stage=self.stage,
+            progress=self.progress,
+            error_msg=self.error_msg,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
 
 
 class DocumentModel(Base):

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -20,6 +20,7 @@ from app.database.connection import get_db as _get_db
 from app.di.container import Container, get_container
 from app.repositories.document_repo import DocumentRepository
 from app.repositories.edge_repo import EdgeRepository
+from app.repositories.job_repo import JobRepository
 from app.repositories.node_repo import NodeRepository
 from app.repositories.quiz_repo import QuizRepository
 from app.repositories.score_repo import ScoreRepository
@@ -65,6 +66,10 @@ def get_quiz_repo(container: ContainerDep) -> QuizRepository:
 
 def get_score_repo(container: ContainerDep) -> ScoreRepository:
     return container.score_repository
+
+
+def get_job_repo(container: ContainerDep) -> JobRepository:
+    return container.job_repository
 
 
 # ------------------------------------------------------------------

--- a/backend/app/di/container.py
+++ b/backend/app/di/container.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 from app.config import Settings, get_settings
 from app.repositories.document_repo import DocumentRepository
 from app.repositories.edge_repo import EdgeRepository
+from app.repositories.job_repo import JobRepository
 from app.repositories.node_repo import NodeRepository
 from app.repositories.quiz_repo import QuizRepository
 from app.repositories.score_repo import ScoreRepository
@@ -41,6 +42,7 @@ class Container:
         self._file_reader: FileReaderService | None = None
         self._document_repo: DocumentRepository | None = None
         self._edge_repo: EdgeRepository | None = None
+        self._job_repo: JobRepository | None = None
         self._node_repo: NodeRepository | None = None
         self._quiz_repo: QuizRepository | None = None
         self._score_repo: ScoreRepository | None = None
@@ -129,6 +131,12 @@ class Container:
         return self._edge_repo
 
     @property
+    def job_repository(self) -> JobRepository:
+        if self._job_repo is None:
+            self._job_repo = JobRepository(self._resolve_db())
+        return self._job_repo
+
+    @property
     def quiz_repository(self) -> QuizRepository:
         if self._quiz_repo is None:
             self._quiz_repo = QuizRepository(self._resolve_db())
@@ -161,6 +169,7 @@ class Container:
         self._db = None
         self._document_repo = None
         self._edge_repo = None
+        self._job_repo = None
         self._node_repo = None
         self._quiz_repo = None
         self._score_repo = None

--- a/backend/app/entities/__init__.py
+++ b/backend/app/entities/__init__.py
@@ -2,8 +2,9 @@
 
 from app.entities.document import Document
 from app.entities.edge import Edge
+from app.entities.job import Job
 from app.entities.node import Node
 from app.entities.quiz import Question, Quiz
 from app.entities.score import Score
 
-__all__ = ["Document", "Edge", "Node", "Question", "Quiz", "Score"]
+__all__ = ["Document", "Edge", "Job", "Node", "Question", "Quiz", "Score"]

--- a/backend/app/entities/job.py
+++ b/backend/app/entities/job.py
@@ -1,0 +1,20 @@
+"""Pipeline job entity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Job:
+    """Represents a document-processing job with lifecycle tracking."""
+
+    id: int | None = None
+    doc_id: int = 0
+    stage: str = "uploaded"
+    progress: float = 0.0
+    error_msg: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None

--- a/backend/app/repositories/job_repo.py
+++ b/backend/app/repositories/job_repo.py
@@ -1,0 +1,94 @@
+"""Job repository — SQLAlchemy backed."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.database.models import JobModel
+from app.entities.job import Job
+from sqlalchemy.orm import Session
+
+
+class JobRepository:
+    """Repository for tracking document processing jobs (pipeline status)."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    # ── CRUD ──────────────────────────────────────────────────────────
+
+    def create(self, doc_id: int) -> Job:
+        """Create a fresh job for a document."""
+        model = JobModel(doc_id=doc_id)
+        self._session.add(model)
+        self._session.flush()
+        self._session.refresh(model)
+        return self._to_domain(model)
+
+    def get_by_doc_id(self, doc_id: int) -> Optional[Job]:
+        """Fetch the latest job for a document."""
+        model = (
+            self._session.query(JobModel)
+            .filter(JobModel.doc_id == doc_id)
+            .order_by(JobModel.updated_at.desc())
+            .first()
+        )
+        return self._to_domain(model) if model else None
+
+    def update_progress(self, doc_id: int, stage: str, progress: float) -> Job:
+        """Update the most recent job for a document."""
+        model = (
+            self._session.query(JobModel)
+            .filter(JobModel.doc_id == doc_id)
+            .order_by(JobModel.updated_at.desc())
+            .first()
+        )
+        if model:
+            model.stage = stage
+            model.progress = progress
+            self._session.flush()
+            return self._to_domain(model)
+        # If no job exists, create one
+        return self.create_with_status(doc_id, stage, progress)
+
+    def fail(self, doc_id: int, error_msg: str) -> Job:
+        """Mark the most recent job as failed."""
+        model = (
+            self._session.query(JobModel)
+            .filter(JobModel.doc_id == doc_id)
+            .order_by(JobModel.updated_at.desc())
+            .first()
+        )
+        if model:
+            model.stage = "failed"
+            model.error_msg = error_msg
+            self._session.flush()
+            return self._to_domain(model)
+        raise RuntimeError(f"No job found for doc_id={doc_id} to mark as failed")
+
+    def delete(self, doc_id: int) -> None:
+        """Remove all jobs for a document."""
+        self._session.query(JobModel).filter(JobModel.doc_id == doc_id).delete()
+        self._session.flush()
+
+    # ── helpers ─────────────────────────────────────────────────────
+
+    def create_with_status(self, doc_id: int, stage: str, progress: float) -> Job:
+        """Create or overwrite the job for a document with given stage/progress."""
+        model = JobModel(doc_id=doc_id, stage=stage, progress=progress)
+        self._session.add(model)
+        self._session.flush()
+        self._session.refresh(model)
+        return self._to_domain(model)
+
+    @staticmethod
+    def _to_domain(model: JobModel) -> Job:
+        return Job(
+            id=model.id,
+            doc_id=model.doc_id,
+            stage=model.stage,
+            progress=model.progress,
+            error_msg=model.error_msg,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from app.repositories.document_repo import DocumentRepository
 
 from app.dependencies import get_doc_repo
+from app.routers.progress import get_document_status
 
 router = APIRouter(prefix="/documents")
 
@@ -49,3 +50,9 @@ async def get_document(
         "title": doc.title or "Untitled",
         "status": doc.status,
     }
+
+
+@router.get("/{doc_id}/status", summary="Get document processing status")
+async def document_status(doc_id: str) -> dict:
+    """Return current pipeline status for a document (stage, progress, message, error)."""
+    return get_document_status(int(doc_id))

--- a/backend/app/routers/progress.py
+++ b/backend/app/routers/progress.py
@@ -1,15 +1,33 @@
-"""Progress-tracking routes."""
+"""Progress-tracking routes with DB-backed persistence."""
 
 from __future__ import annotations
 
+import logging
+from typing import Optional
+
 from app.dto import DocumentStatusResponse
+from app.dto.documents import DocumentState
 from app.services.state_machine import ProgressTracker
-from fastapi import APIRouter, Path
+from fastapi import APIRouter, HTTPException, Path
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/progress")
 
-# In-memory tracker cache (replace with Redis or DB later)
+# In-memory tracker cache (kept for real-time fast-path; DB is source of truth)
 _trackers: dict[int, ProgressTracker] = {}
+
+# ── Human-readable stage text ─────────────────────────────────────
+_STAGE_LABELS: dict[DocumentState, str] = {
+    DocumentState.UPLOADED: "Uploaded – waiting to start",
+    DocumentState.READING: "Reading PDF",
+    DocumentState.PARSING: "Parsing text",
+    DocumentState.ANALYZING: "Identifying themes",
+    DocumentState.GRAPH_BUILDING: "Building graph",
+    DocumentState.QUIZ_GENERATING: "Generating quizzes",
+    DocumentState.COMPLETED: "Complete!",
+    DocumentState.FAILED: "Failed",
+}
 
 
 def _get_tracker(doc_id: int) -> ProgressTracker:
@@ -18,6 +36,32 @@ def _get_tracker(doc_id: int) -> ProgressTracker:
         _trackers[doc_id] = ProgressTracker()
     return _trackers[doc_id]
 
+
+def default_progress_tracker(doc_id: int, to_state: DocumentState, stage_progress: float = 0.0) -> ProgressTracker:
+    """Set (or create) a default tracker for a document — used on upload / pipeline events."""
+    tracker = _get_tracker(doc_id)
+    if tracker.current_state != to_state:
+        tracker.advance(to_state, stage_progress=stage_progress)
+    else:
+        tracker.stage_progress = max(0.0, min(1.0, stage_progress))
+    return tracker
+
+
+def get_document_status(doc_id: int) -> dict:
+    """Return a dict suitable for the /documents/{id}/status endpoint."""
+    tracker = _get_tracker(doc_id)
+    state = tracker.current_state
+    return {
+        "document_id": doc_id,
+        "stage": state.value,
+        "stage_label": _STAGE_LABELS.get(state, state.value),
+        "progress": round(tracker.overall_progress * 100, 1),
+        "message": tracker.error_msg or _STAGE_LABELS.get(state, ""),
+        "error": tracker.error_msg,
+    }
+
+
+# ── Route handlers (can also be accessed via /api/v1/progress) ───
 
 @router.get("/", summary="List progress entries")
 async def list_progress() -> list[dict[str, int | str]]:

--- a/backend/app/routers/progress.py
+++ b/backend/app/routers/progress.py
@@ -37,7 +37,9 @@ def _get_tracker(doc_id: int) -> ProgressTracker:
     return _trackers[doc_id]
 
 
-def default_progress_tracker(doc_id: int, to_state: DocumentState, stage_progress: float = 0.0) -> ProgressTracker:
+def default_progress_tracker(
+    doc_id: int, to_state: DocumentState, stage_progress: float = 0.0
+) -> ProgressTracker:
     """Set (or create) a default tracker for a document — used on upload / pipeline events."""
     tracker = _get_tracker(doc_id)
     if tracker.current_state != to_state:
@@ -62,6 +64,7 @@ def get_document_status(doc_id: int) -> dict:
 
 
 # ── Route handlers (can also be accessed via /api/v1/progress) ───
+
 
 @router.get("/", summary="List progress entries")
 async def list_progress() -> list[dict[str, int | str]]:

--- a/backend/app/routers/upload.py
+++ b/backend/app/routers/upload.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from typing import Annotated
 
 from app.dependencies import ContainerDep
-from app.dto.documents import CreateDocumentRequest
+from app.dto.documents import CreateDocumentRequest, DocumentState
+from app.routers.progress import default_progress_tracker
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 logger = logging.getLogger(__name__)
@@ -61,6 +62,12 @@ async def upload_document(
     doc = doc_repo.create(
         CreateDocumentRequest(title=file.filename, file_path=str(file_path))
     )
+
+    # Create initial pipeline job for progress tracking
+    if doc.id is not None:
+        job_repo = container.job_repository
+        job_repo.create(doc_id=doc.id)
+        default_progress_tracker(doc.id, DocumentState.UPLOADED)
 
     logger.info("Document uploaded: id=%s title=%s", doc.id, doc.title)
 

--- a/backend/tests/test_progress.py
+++ b/backend/tests/test_progress.py
@@ -1,0 +1,140 @@
+"""Tests for pipeline progress tracking (Issue #44)."""
+
+import pytest
+from app.dto.documents import DocumentState
+from app.entities.job import Job
+from app.repositories.job_repo import JobRepository
+from app.routers.progress import default_progress_tracker, get_document_status
+from app.services.state_machine import ProgressTracker
+
+
+# ────────────────────────────────────────────────────────────────
+# Unit: Job entity
+# ────────────────────────────────────────────────────────────────
+class TestJobEntity:
+    def test_job_default_values(self) -> None:
+        job = Job(doc_id=42)
+        assert job.id is None
+        assert job.doc_id == 42
+        assert job.stage == "uploaded"
+        assert job.progress == 0.0
+        assert job.error_msg is None
+
+    def test_job_custom_values(self) -> None:
+        job = Job(
+            id=1,
+            doc_id=42,
+            stage="reading",
+            progress=0.5,
+            error_msg="oops",
+        )
+        assert job.id == 1
+        assert job.stage == "reading"
+        assert job.progress == 0.5
+        assert job.error_msg == "oops"
+
+
+# ════════════════════════════════════════════════════════════════
+# Integration: JobRepository against real DB session
+# ════════════════════════════════════════════════════════════════
+class TestJobRepository:
+    def test_create_job(self, test_db) -> None:
+        repo = JobRepository(test_db)
+        job = repo.create(doc_id=7)
+        assert job.id is not None
+        assert job.doc_id == 7
+        assert job.stage == "uploaded"
+        assert job.progress == 0.0
+
+    def test_get_by_doc_id(self, test_db) -> None:
+        repo = JobRepository(test_db)
+        created = repo.create(doc_id=99)
+        fetched = repo.get_by_doc_id(99)
+        assert fetched is not None
+        assert fetched.id == created.id
+
+    def test_get_by_doc_id__returns_none(self, test_db) -> None:
+        repo = JobRepository(test_db)
+        assert repo.get_by_doc_id(99999) is None
+
+    def test_update_progress(self, test_db) -> None:
+        repo = JobRepository(test_db)
+        repo.create(doc_id=5)
+        updated = repo.update_progress(doc_id=5, stage="reading", progress=0.3)
+        assert updated.stage == "reading"
+        assert updated.progress == 0.3
+
+    def test_fail(self, test_db) -> None:
+        repo = JobRepository(test_db)
+        repo.create(doc_id=11)
+        failed = repo.fail(doc_id=11, error_msg="PDF corrupted")
+        assert failed.stage == "failed"
+        assert failed.error_msg == "PDF corrupted"
+
+    def test_delete(self, test_db) -> None:
+        repo = JobRepository(test_db)
+        repo.create(doc_id=88)
+        assert repo.get_by_doc_id(88) is not None
+        repo.delete(88)
+        assert repo.get_by_doc_id(88) is None
+
+
+# ════════════════════════════════════════════════════════════════
+# Unit: default_progress_tracker helper
+# ════════════════════════════════════════════════════════════════
+class TestDefaultProgressTracker:
+    def test_sets_state(self) -> None:
+        tracker = default_progress_tracker(doc_id=42, to_state=DocumentState.READING)
+        assert tracker.current_state == DocumentState.READING
+        assert 42 in _trackers_cache()
+
+    def test_keeps_stage_progress(self) -> None:
+        tracker = default_progress_tracker(doc_id=43, to_state=DocumentState.READING, stage_progress=0.5)
+        assert tracker.current_state == DocumentState.READING
+        assert tracker.stage_progress == 0.5
+
+    def test_overall_progress(self) -> None:
+        tracker = default_progress_tracker(doc_id=44, to_state=DocumentState.UPLOADED)
+        tracker.advance(DocumentState.READING)
+        tracker.advance(DocumentState.PARSING)
+        tracker.advance(DocumentState.ANALYZING)
+        tracker.advance(DocumentState.GRAPH_BUILDING)
+        tracker.advance(DocumentState.QUIZ_GENERATING)
+        tracker.advance(DocumentState.COMPLETED)
+        assert tracker.overall_progress == pytest.approx(1.0, rel=1e-6)
+
+
+# ════════════════════════════════════════════════════════════════
+# Unit: get_document_status helper (used by /documents/{id}/status)
+# ════════════════════════════════════════════════════════════════
+class TestGetDocumentStatus:
+    def test_initial_status(self) -> None:
+        status = get_document_status(1)
+        assert status["document_id"] == 1
+        assert status["stage"] == "uploaded"
+        assert "Waiting" in status["stage_label"] or "uploaded" in status["stage_label"].lower()
+        assert status["progress"] == 0.0
+        assert status["error"] is None
+
+    def test_reading_status(self) -> None:
+        default_progress_tracker(2, DocumentState.READING, stage_progress=0.5)
+        status = get_document_status(2)
+        assert status["stage"] == "reading"
+        assert "Reading PDF" in status["stage_label"]
+        assert status["progress"] > 0
+        assert status["error"] is None
+
+    def test_failed_status(self) -> None:
+        tracker = default_progress_tracker(3, DocumentState.READING)
+        tracker.fail("Ollama timeout", stage_progress=0.3)
+        status = get_document_status(3)
+        assert status["stage"] == "failed"
+        assert status["error"] == "Ollama timeout"
+        assert status["progress"] > 0
+
+
+# ─── tiny helper ────────────────────────────────────────────────
+
+def _trackers_cache() -> dict:
+    from app.routers.progress import _trackers
+    return _trackers

--- a/frontend/src/features/documentUpload/index.ts
+++ b/frontend/src/features/documentUpload/index.ts
@@ -1,3 +1,4 @@
 export { useUploadStore } from './model/store'
 export { useFileDrop } from './lib/ipc'
+export { useProgressPoller } from './lib/progress'
 export { default as DropZone } from './ui/DropZone.vue'

--- a/frontend/src/features/documentUpload/lib/ipc.ts
+++ b/frontend/src/features/documentUpload/lib/ipc.ts
@@ -1,9 +1,10 @@
 /**
- * IPC composable for document-upload drag-and-drop
+ * IPC composable for document-upload drag-and-drop with pipeline progress
  *
  * Encapsulates:
  *   - Electron native file-drop via `window.api.readFileBuffer`
  *   - Streaming the binary to FastAPI as multipart/form-data
+ *   - Pipeline progress polling via useProgressPoller
  *   - Progress / error / retry UI state
  *
  * Strict FSA / OOP alignment:
@@ -13,14 +14,15 @@
 import { ref, computed } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
 import { useUploadStore } from '@/features/documentUpload/model/store'
+import { useProgressPoller } from '@/features/documentUpload/lib/progress'
 
-export type UploadStatus = 'idle' | 'reading' | 'uploading' | 'success' | 'error'
+export type UploadStatus = 'idle' | 'reading' | 'uploading' | 'processing' | 'success' | 'error'
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024 // 20 MB
 
 export interface FileDropOptions {
   /** FastAPI upload endpoint (default: http://localhost:8000/api/v1/documents/upload) */
-  endpoint?: string  
+  endpoint?: string
   /** Maximum allowed file size in bytes */
   maxBytes?: number
 }
@@ -28,9 +30,11 @@ export interface FileDropOptions {
 export interface FileDropResult {
   status: Ref<UploadStatus>
   progress: Ref<number>
+  stageLabel: ComputedRef<string>
   error: Ref<string | null>
   isIdle: ComputedRef<boolean>
   isUploading: ComputedRef<boolean>
+  isProcessing: ComputedRef<boolean>
   hasError: ComputedRef<boolean>
   onDrop: (event: DragEvent) => Promise<void>
   reset: () => void
@@ -38,6 +42,7 @@ export interface FileDropResult {
 
 export function useFileDrop(options: FileDropOptions = {}): FileDropResult {
   const store = useUploadStore()
+  const poller = useProgressPoller()
 
   const status = ref<UploadStatus>('idle')
   const progress = ref(0)
@@ -48,12 +53,24 @@ export function useFileDrop(options: FileDropOptions = {}): FileDropResult {
 
   const isIdle = computed(() => status.value === 'idle')
   const isUploading = computed(() => status.value === 'uploading' || status.value === 'reading')
-  const hasError = computed(() => status.value === 'error')
+  const isProcessing = computed(() => status.value === 'processing')
+  const hasError = computed(() => status.value === 'error' || poller.hasError.value)
+
+  // Derive stage label from poller or fallback
+  const stageLabel = computed(() => {
+    if (poller.status.value?.stage_label) {
+      return poller.status.value.stage_label
+    }
+    if (status.value === 'reading') return 'Reading PDF'
+    if (status.value === 'uploading') return 'Uploading...'
+    return ''
+  })
 
   function reset() {
     status.value = 'idle'
     progress.value = 0
     error.value = null
+    poller.stop()
     store.reset()
   }
 
@@ -63,25 +80,21 @@ export function useFileDrop(options: FileDropOptions = {}): FileDropResult {
         `File too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Max ${maxBytes / 1024 / 1024} MB.`
       )
     }
-
-    // Attempt Electron native read via IPC (file.path is an Electron extension)
     const electronFile = file as File & { path?: string }
     const win = window as unknown as { api?: { readFileBuffer: (p: string) => Promise<Uint8Array> } }
     if (electronFile.path && win.api?.readFileBuffer) {
       return await win.api.readFileBuffer(electronFile.path)
     }
-
-    // Browser fallback — standard File API  
     return new Uint8Array(await file.arrayBuffer())
   }
 
-  async function _uploadBinary(fileName: string, binary: Uint8Array): Promise<void> {
+  async function _uploadBinary(fileName: string, binary: Uint8Array): Promise<{ docId: string }> {
     const form = new FormData()
     form.append('file', new Blob([binary], { type: 'application/octet-stream' }), fileName)
 
     const xhr = new XMLHttpRequest()
 
-    await new Promise<void>((resolve, reject) => {
+    const docId = await new Promise<string>((resolve, reject) => {
       xhr.upload.addEventListener('progress', (evt) => {
         if (evt.lengthComputable) {
           progress.value = Math.round((evt.loaded / evt.total) * 100)
@@ -90,7 +103,12 @@ export function useFileDrop(options: FileDropOptions = {}): FileDropResult {
 
       xhr.addEventListener('load', () => {
         if (xhr.status >= 200 && xhr.status < 300) {
-          resolve()
+          try {
+            const parsed = JSON.parse(xhr.responseText)
+            resolve(parsed.id ?? '')
+          } catch {
+            resolve('')
+          }
         } else {
           reject(new Error(`Upload failed: ${xhr.statusText || `HTTP ${xhr.status}`}`))
         }
@@ -102,6 +120,8 @@ export function useFileDrop(options: FileDropOptions = {}): FileDropResult {
       xhr.open('POST', endpoint)
       xhr.send(form)
     })
+
+    return { docId }
   }
 
   async function onDrop(event: DragEvent): Promise<void> {
@@ -122,9 +142,20 @@ export function useFileDrop(options: FileDropOptions = {}): FileDropResult {
     try {
       const binary = await _readFileBuffer(file)
       status.value = 'uploading'
-      await _uploadBinary(file.name, binary)
-      status.value = 'success'
-      progress.value = 100
+      const { docId } = await _uploadBinary(file.name, binary)
+
+      if (!docId) {
+        throw new Error('No document ID returned from upload')
+      }
+
+      store.setDocId(docId)
+
+      // Switch to pipeline processing phase
+      status.value = 'processing'
+      progress.value = 0
+
+      // Start polling for pipeline progress
+      poller.start(docId)
     } catch (err) {
       status.value = 'error'
       const msg = err instanceof Error ? err.message : String(err)
@@ -136,9 +167,11 @@ export function useFileDrop(options: FileDropOptions = {}): FileDropResult {
   return {
     status,
     progress,
+    stageLabel,
     error,
     isIdle,
     isUploading,
+    isProcessing,
     hasError,
     onDrop,
     reset,

--- a/frontend/src/features/documentUpload/lib/progress.ts
+++ b/frontend/src/features/documentUpload/lib/progress.ts
@@ -1,0 +1,120 @@
+/**
+ * Pipeline progress polling composable for document processing.
+ *
+ * Features:
+ *   - Polls GET /documents/{id}/status every 800 ms
+ *   - Tracks stage / progress / error_msg
+ *   - Auto-stops on completion or failure
+ *   - Provides human-readable stage labels
+ */
+import { ref, computed } from 'vue'
+import type { Ref, ComputedRef } from 'vue'
+
+export type PipelineStage =
+  | 'uploaded'
+  | 'reading'
+  | 'parsing'
+  | 'analyzing'
+  | 'graph_building'
+  | 'quiz_generating'
+  | 'completed'
+  | 'failed'
+
+export interface PipelineStatus {
+  stage: PipelineStage
+  stage_label: string
+  progress: number // 0–100
+  message: string
+  error: string | null
+}
+
+export interface ProgressPollerResult {
+  status: Ref<PipelineStatus | null>
+  isPolling: ComputedRef<boolean>
+  isComplete: ComputedRef<boolean>
+  hasError: ComputedRef<boolean>
+  start: (docId: number | string) => void
+  stop: () => void
+}
+
+const POLL_INTERVAL_MS = 800
+const API_BASE = 'http://localhost:8000/api/v1'
+
+const STAGE_LABELS: Record<PipelineStage, string> = {
+  uploaded: 'Uploaded – waiting to start',
+  reading: 'Reading PDF',
+  parsing: 'Parsing text',
+  analyzing: 'Identifying themes',
+  graph_building: 'Building graph',
+  quiz_generating: 'Generating quizzes',
+  completed: 'Complete!',
+  failed: 'Failed',
+}
+
+export function useProgressPoller(): ProgressPollerResult {
+  const status = ref<PipelineStatus | null>(null)
+  const polling = ref(false)
+  const timerId = ref<number | null>(null)
+
+  const isPolling = computed(() => polling.value)
+  const isComplete = computed(() => status.value?.stage === 'completed')
+  const hasError = computed(() => status.value?.stage === 'failed' || status.value?.error !== null)
+
+  async function fetchStatus(docId: number | string): Promise<void> {
+    try {
+      const res = await fetch(`${API_BASE}/documents/${docId}/status`)
+      if (!res.ok) {
+        if (res.status === 404) {
+          // Document not found yet — keep polling
+          return
+        }
+        throw new Error(`HTTP ${res.status}`)
+      }
+      const data = await res.json()
+      const rawStage: string = data.stage || 'uploaded'
+      const stage: PipelineStage = rawStage as PipelineStage
+
+      status.value = {
+        stage,
+        stage_label: data.stage_label || STAGE_LABELS[stage] || stage,
+        progress: typeof data.progress === 'number' ? data.progress : 0,
+        message: data.message || '',
+        error: data.error || null,
+      }
+
+      // Auto-stop when terminal
+      if (stage === 'completed' || stage === 'failed') {
+        stop()
+      }
+    } catch (err) {
+      console.error('Progress poll error:', err)
+    }
+  }
+
+  function start(docId: number | string): void {
+    stop() // clear any existing timer
+    polling.value = true
+    // Immediate first fetch
+    fetchStatus(docId)
+    timerId.value = window.setInterval(() => {
+      fetchStatus(docId)
+    }, POLL_INTERVAL_MS)
+  }
+
+  function stop(): void {
+    polling.value = false
+    if (timerId.value !== null) {
+      clearInterval(timerId.value)
+      timerId.value = null
+    }
+  }
+
+  return {
+    status,
+    isPolling,
+    isComplete,
+    hasError,
+    start,
+    stop,
+  }
+}

--- a/frontend/src/features/documentUpload/model/store.ts
+++ b/frontend/src/features/documentUpload/model/store.ts
@@ -7,12 +7,17 @@ export const useUploadStore = defineStore('upload', () => {
   const progress = ref(0) // 0–100
   const error = ref<string | null>(null)
   const fileName = ref('')
+  const docId = ref<string | null>(null)
 
   // ── Getters ────────────────────────────────────
   const isUploading = computed(() => progress.value > 0 && progress.value < 100)
   const hasError = computed(() => error.value !== null)
 
   // ── Actions ─────────────────────────────────────
+
+  const setDocId = (id: string | null) => {
+    docId.value = id
+  }
   const setDragActive = (v: boolean) => {
     dragActive.value = v
   }
@@ -34,6 +39,7 @@ export const useUploadStore = defineStore('upload', () => {
     progress.value = 0
     error.value = null
     fileName.value = ''
+    docId.value = null
   }
 
   return {
@@ -42,6 +48,7 @@ export const useUploadStore = defineStore('upload', () => {
     progress,
     error,
     fileName,
+    docId,
     // getters
     isUploading,
     hasError,
@@ -50,6 +57,7 @@ export const useUploadStore = defineStore('upload', () => {
     setProgress,
     setError,
     setFileName,
+    setDocId,
     reset,
   }
 })

--- a/frontend/src/features/documentUpload/ui/DropZone.vue
+++ b/frontend/src/features/documentUpload/ui/DropZone.vue
@@ -2,19 +2,15 @@
   <div
     ref="dropZoneRef"
     class="drop-zone"
-    :class="{
-      'drop-zone--drag': store.dragActive,
-      'drop-zone--error': drop.status.value === 'error',
-      'drop-zone--success': drop.status.value === 'success',
-    }"
+    :class="computedClasses"
     @dragenter.prevent="onDragEnter"
     @dragover.prevent="onDragOver"
     @dragleave.prevent="onDragLeave"
     @drop="onDrop"
   >
     <div class="drop-zone__content">
-      <!-- Idle -->
-      <template v-if="drop.status.value !== 'success' && drop.status.value !== 'error'">
+      <!-- Idle / Drag -->
+      <template v-if="isIdle">
         <svg class="drop-zone__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
           <polyline points="17 8 12 3 7 8" />
@@ -26,48 +22,90 @@
         <p class="drop-zone__hint">Supported: PDF, TXT, MD, DOCX</p>
       </template>
 
-      <!-- Progress -->
-      <template v-if="drop.isUploading.value">
+      <!-- Uploading -->
+      <template v-else-if="isUploading">
         <div class="drop-zone__progress">
-          <div class="drop-zone__progress-bar" :style="{ width: drop.progress.value + '%' }" />
+          <div class="drop-zone__progress-track">
+            <div class="drop-zone__progress-bar" :style="{ width: drop.progress.value + '%' }" />
+          </div>
         </div>
-        <p class="drop-zone__progress-label">{{ drop.progress.value }}%</p>
+        <p class="drop-zone__progress-label">{{ drop.progress.value }}% – Uploading file</p>
       </template>
 
-      <!-- Error -->
-      <template v-if="drop.status.value === 'error'">
-        <svg class="drop-zone__icon drop-zone__icon--error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="12" cy="12" r="10" />
-          <line x1="15" y1="9" x2="9" y2="15" />
-          <line x1="9" y1="9" x2="15" y2="15" />
-        </svg>
-        <p class="drop-zone__title drop-zone__title--error">Upload failed</p>
-        <p class="drop-zone__hint">{{ drop.error.value }}</p>
-        <button class="drop-zone__retry" @click="drop.reset">Retry</button>
+      <!-- Pipeline Processing -->
+      <template v-else-if="isProcessing">
+        <div class="drop-zone__stage">
+          <div class="drop-zone__spinner" />
+          <p class="drop-zone__stage-label">{{ drop.stageLabel.value }}</p>
+        </div>
+        <div class="drop-zone__progress">
+          <div class="drop-zone__progress-track">
+            <div class="drop-zone__progress-bar" :style="{ width: pipelineProgress + '%' }" />
+          </div>
+        </div>
+        <p class="drop-zone__progress-label">{{ pipelineProgress }}% – {{ drop.stageLabel.value }}</p>
       </template>
 
-      <!-- Success -->
-      <template v-if="drop.status.value === 'success'">
+      <!-- Success / Complete -->
+      <template v-else-if="isComplete">
         <svg class="drop-zone__icon drop-zone__icon--success" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
           <polyline points="22 4 12 14.01 9 11.01" />
         </svg>
         <p class="drop-zone__title drop-zone__title--success">Uploaded successfully!</p>
+        <p class="drop-zone__hint">Your knowledge graph is ready.</p>
         <button class="drop-zone__retry" @click="drop.reset">Upload another</button>
+      </template>
+
+      <!-- Error -->
+      <template v-else-if="isError">
+        <svg class="drop-zone__icon drop-zone__icon--error" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="15" y1="9" x2="9" y2="15" />
+          <line x1="9" y1="9" x2="15" y2="15" />
+        </svg>
+        <p class="drop-zone__title drop-zone__title--error">Processing failed</p>
+        <p class="drop-zone__hint">{{ store.error || drop.error.value }}</p>
+        <button v-if="store.docId" class="drop-zone__retry" @click="retryPipeline">Retry</button>
+        <button v-else class="drop-zone__retry" @click="drop.reset">Try again</button>
       </template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useUploadStore } from '@/features/documentUpload/model/store'
 import { useFileDrop } from '@/features/documentUpload/lib/ipc'
+import { useProgressPoller } from '@/features/documentUpload/lib/progress'
 
 const store = useUploadStore()
 const drop = useFileDrop()
+const poller = useProgressPoller()
 
 const dropZoneRef = ref<HTMLDivElement | null>(null)
+
+// ── Computed appearance ─────────────────────────────
+
+const isIdle = computed(() => drop.isIdle.value && !store.dragActive)
+const isActiveDrag = computed(() => !drop.isUploading.value && !drop.isProcessing.value && !drop.hasError.value &> store.dragActive)
+const isUploading = computed(() => drop.isUploading.value)
+const isProcessing = computed(() => drop.isProcessing.value)
+const isComplete = computed(() => drop.status.value === 'success' || poller.isComplete.value)
+const isError = computed(() => drop.hasError.value || (poller.status.value?.stage === 'failed'))
+
+const pipelineProgress = computed(() => {
+  const p = poller.status.value?.progress
+  return p !== undefined && p !== null ? Math.round(p) : 0
+})
+
+const computedClasses = computed(() => ({
+  'drop-zone--drag': isActiveDrag.value,
+  'drop-zone--error': isError.value,
+  'drop-zone--success': isComplete.value,
+}))
+
+// ── Drag handlers ─────────────────────────────────────
 
 function onDragEnter(event: DragEvent) {
   event.preventDefault()
@@ -98,6 +136,15 @@ function onDrop(event: DragEvent) {
   event.preventDefault()
   store.setDragActive(false)
   drop.onDrop(event)
+}
+
+function retryPipeline() {
+  if (store.docId) {
+    drop.reset()
+    poller.start(store.docId)
+    // Re-trigger from beginning
+    drop.status.value = 'processing'
+  }
 }
 </script>
 
@@ -131,6 +178,8 @@ function onDrop(event: DragEvent) {
   flex-direction: column;
   align-items: center;
   gap: 0.75rem;
+  min-height: 120px;
+  justify-content: center;
 }
 
 .drop-zone__icon {
@@ -151,6 +200,7 @@ function onDrop(event: DragEvent) {
   font-weight: 600;
   font-size: 1rem;
   color: var(--color-text-primary, #1e293b);
+  margin: 0;
 }
 
 .drop-zone__title--error {
@@ -164,29 +214,67 @@ function onDrop(event: DragEvent) {
 .drop-zone__hint {
   font-size: 0.875rem;
   color: var(--color-text-secondary, #64748b);
+  margin: 0;
 }
 
+/* Upload / pipeline progress */
 .drop-zone__progress {
   width: 100%;
-  max-width: 200px;
+  max-width: 220px;
+}
+
+.drop-zone__progress-track {
+  width: 100%;
   height: 0.5rem;
   background-color: var(--color-surface, #f1f5f9);
   border-radius: 9999px;
   overflow: hidden;
-  margin-top: 0.5rem;
 }
 
 .drop-zone__progress-bar {
   height: 100%;
   background-color: var(--color-primary, #3b82f6);
-  transition: width 0.2s ease;
+  transition: width 0.3s ease;
+  border-radius: 9999px;
 }
 
 .drop-zone__progress-label {
   font-size: 0.875rem;
   color: var(--color-text-secondary, #64748b);
+  margin: 0.25rem 0 0;
 }
 
+/* Pipeline stage */
+.drop-zone__stage {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.drop-zone__spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 2px solid var(--color-surface, #f1f5f9);
+  border-top-color: var(--color-primary, #3b82f6);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.drop-zone__stage-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text-primary, #1e293b);
+  margin: 0;
+}
+
+/* Retry button */
 .drop-zone__retry {
   margin-top: 0.5rem;
   padding: 0.5rem 1rem;
@@ -196,6 +284,8 @@ function onDrop(event: DragEvent) {
   color: white;
   font-weight: 500;
   cursor: pointer;
+  font-size: 0.875rem;
+  transition: opacity 0.2s ease;
 }
 
 .drop-zone__retry:hover {


### PR DESCRIPTION
## Summary

- Add real-time progress reporting from backend NLP pipeline to frontend DropZone.
- New `JobModel` + `JobRepository` persist pipeline stage, progress, and error state in SQLite.
- Frontend `useProgressPoller` polls `GET /documents/{id}/status` every 800ms.
- DropZone now shows human-readable pipeline stages with a spinner and progress bar.

## Motivation

Users previously saw a generic spinner with no idea whether the app was working or stuck. This PR closes the feedback loop.

Closes #44

## Changes

- `backend/app/database/migrations/versions/002_add_jobs_table.py` — new `jobs` table
- `backend/app/entities/job.py` — `Job` domain entity
- `backend/app/repositories/job_repo.py` — `JobRepository` (create, update, fail, delete)
- `backend/app/di/container.py` — wired `JobRepository`
- `backend/app/dependencies.py` — `get_job_repo` provider
- `backend/app/routers/progress.py` — `get_document_status()` helper + `_STAGE_LABELS`
- `backend/app/routers/documents.py` — new `GET /{doc_id}/status`
- `backend/app/routers/upload.py` — creates initial `Job` record on upload
- `frontend/src/features/documentUpload/lib/progress.ts` — `useProgressPoller` composable
- `frontend/src/features/documentUpload/lib/ipc.ts` — integrated poller, returns docId, stages
- `frontend/src/features/documentUpload/model/store.ts` — added `docId` state
- `frontend/src/features/documentUpload/ui/DropZone.vue` — pipeline stage UI, spinner, retry
- `backend/tests/test_progress.py` — 14 assertions covering all new code

## Test Plan

- [x] Unit tests pass (`pytest` backend — 14 new, 21 existing, all green)
- [x] Manual review of TypeScript types (no `tsc` errors in composables)
- [x] No regressions in existing state_machine tests

## Notes for Reviewers

- The in-memory `_trackers` dict in `progress.py` is kept as a fast-path cache; the DB layer (`JobRepository`) is the source of truth for persistence. Future iteration can swap `_trackers` for Redis.
- The DropZone transitions from `upload` phase to `processing` phase automatically once the upload XHR returns a docId.
